### PR TITLE
[v0.0.0] display only issuer,subject, validity, X509v3 Subject Alternative Name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright © 2023 kanywst ash00le1234@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,67 @@
 # s3heck
 
+- [s3heck](#s3heck)
+  - [Install](#install)
+  - [Usage](#usage)
+    - [Help](#help)
+    - [Example](#example)
+
 s3heck is a command line interface that can perform checks on the certificate chain.
 
 ## Install
 
+```bash
+git clone https://github.com/kanywst/s3heck.git
+cd s3heck
+go install
+```
+
 ## Usage
+
+### Help
+
+```bash
+$ s3heck x509 -h
+display necessary information about x509 certificates
+
+Usage:
+  s3heck x509 [flags]
+
+Flags:
+  -d, --dns          display subject alternative name
+  -h, --help         help for x509
+  -i, --issuer       display issuer
+  -p, --pem string   specify certificate input pem
+  -s, --subject      display subject
+  -v, --validity     display validity
+```
+
+### Example
+
+```bash
+$ s3heck x509 -p ./data/cert.pem --issuer --subject --validity --dns
+Certificate [1]
+  Issuer: R3
+  Subject: kanywst.top
+  Validity:
+    NotBefore: 2023-03-31 13:32:00 +0000 UTC
+    NotAfter: 2023-06-29 13:31:59 +0000 UTC
+  X509v3 extensions
+    X509v3 Subject Alternative Name: kanywst.top, tbow.kanywst.top
+Certificate [2]
+  Issuer: ISRG Root X1
+  Subject: R3
+  Validity:
+    NotBefore: 2020-09-04 00:00:00 +0000 UTC
+    NotAfter: 2025-09-15 16:00:00 +0000 UTC
+  X509v3 extensions
+    X509v3 Subject Alternative Name:
+Certificate [3]
+  Issuer: DST Root CA X3
+  Subject: ISRG Root X1
+  Validity:
+    NotBefore: 2021-01-20 19:14:03 +0000 UTC
+    NotAfter: 2024-09-30 18:14:03 +0000 UTC
+  X509v3 extensions
+    X509v3 Subject Alternative Name:
+```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2023 kanywst ash00le1234@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// rootCmd represents the base command when called without any subcommands
+var rootCmd = &cobra.Command{
+	Use:   "s3heck",
+	Short: "s3heck is a command line interface that can perform checks on the certificate chain.",
+}
+
+func Execute() {
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,7 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "s3heck",
 	Short: "s3heck is a command line interface that can perform checks on the certificate chain.",

--- a/cmd/x509.go
+++ b/cmd/x509.go
@@ -1,6 +1,3 @@
-/*
-Copyright © 2023 kanywst ash00le1234@gmail.com
-*/
 package cmd
 
 import (
@@ -14,6 +11,7 @@ type Options struct {
 	certificateFileName string
 	issuerCommonName    bool
 	subjectCommonName   bool
+	validity            bool
 }
 
 var (
@@ -25,7 +23,7 @@ var x509Cmd = &cobra.Command{
 	Use:   "x509",
 	Short: "display x509 certificate",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(certificate.GetX509Information(o.certificateFileName, o.issuerCommonName, o.subjectCommonName))
+		fmt.Print(certificate.GetX509Information(o.certificateFileName, o.issuerCommonName, o.subjectCommonName, o.validity))
 	},
 }
 
@@ -35,4 +33,5 @@ func init() {
 	x509Cmd.Flags().StringVarP(&o.certificateFileName, "file", "f", "", "Certificate input file")
 	x509Cmd.Flags().BoolVarP(&o.issuerCommonName, "issuer", "i", false, "Display issuer")
 	x509Cmd.Flags().BoolVarP(&o.subjectCommonName, "subject", "s", false, "Display subject")
+	x509Cmd.Flags().BoolVarP(&o.validity, "validity", "v", false, "Display validity")
 }

--- a/cmd/x509.go
+++ b/cmd/x509.go
@@ -12,6 +12,7 @@ type Options struct {
 	issuerCommonName    bool
 	subjectCommonName   bool
 	validity            bool
+	dns                 bool
 }
 
 var (
@@ -23,7 +24,7 @@ var x509Cmd = &cobra.Command{
 	Use:   "x509",
 	Short: "display x509 certificate",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Print(certificate.GetX509Information(o.certificateFileName, o.issuerCommonName, o.subjectCommonName, o.validity))
+		fmt.Print(certificate.GetX509Information(o.certificateFileName, o.issuerCommonName, o.subjectCommonName, o.validity, o.dns))
 	},
 }
 
@@ -34,4 +35,6 @@ func init() {
 	x509Cmd.Flags().BoolVarP(&o.issuerCommonName, "issuer", "i", false, "Display issuer")
 	x509Cmd.Flags().BoolVarP(&o.subjectCommonName, "subject", "s", false, "Display subject")
 	x509Cmd.Flags().BoolVarP(&o.validity, "validity", "v", false, "Display validity")
+	x509Cmd.Flags().BoolVarP(&o.dns, "dns", "d", false, "Display X509v3 Subject Alternative Name")
+
 }

--- a/cmd/x509.go
+++ b/cmd/x509.go
@@ -19,10 +19,9 @@ var (
 	o = &Options{}
 )
 
-// x509Cmd represents the x509 command
 var x509Cmd = &cobra.Command{
 	Use:   "x509",
-	Short: "display x509 certificate",
+	Short: "display necessary information about x509 certificates",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Print(certificate.GetX509Information(o.certificateFileName, o.issuerCommonName, o.subjectCommonName, o.validity, o.dns))
 	},
@@ -31,10 +30,10 @@ var x509Cmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(x509Cmd)
 
-	x509Cmd.Flags().StringVarP(&o.certificateFileName, "file", "f", "", "Certificate input file")
-	x509Cmd.Flags().BoolVarP(&o.issuerCommonName, "issuer", "i", false, "Display issuer")
-	x509Cmd.Flags().BoolVarP(&o.subjectCommonName, "subject", "s", false, "Display subject")
-	x509Cmd.Flags().BoolVarP(&o.validity, "validity", "v", false, "Display validity")
-	x509Cmd.Flags().BoolVarP(&o.dns, "dns", "d", false, "Display X509v3 Subject Alternative Name")
+	x509Cmd.Flags().StringVarP(&o.certificateFileName, "pem", "p", "", "specify certificate input pem")
+	x509Cmd.Flags().BoolVarP(&o.issuerCommonName, "issuer", "i", false, "display issuer")
+	x509Cmd.Flags().BoolVarP(&o.subjectCommonName, "subject", "s", false, "display subject")
+	x509Cmd.Flags().BoolVarP(&o.validity, "validity", "v", false, "display validity")
+	x509Cmd.Flags().BoolVarP(&o.dns, "dns", "d", false, "display subject alternative name")
 
 }

--- a/cmd/x509.go
+++ b/cmd/x509.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2023 kanywst ash00le1234@gmail.com
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kanywst/s3heck/pkg/certificate"
+	"github.com/spf13/cobra"
+)
+
+type Options struct {
+	certificateFileName string
+	issuerCommonName    bool
+	subjectCommonName   bool
+}
+
+var (
+	o = &Options{}
+)
+
+// x509Cmd represents the x509 command
+var x509Cmd = &cobra.Command{
+	Use:   "x509",
+	Short: "display x509 certificate",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(certificate.GetX509Information(o.certificateFileName, o.issuerCommonName, o.subjectCommonName))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(x509Cmd)
+
+	x509Cmd.Flags().StringVarP(&o.certificateFileName, "file", "f", "", "Certificate input file")
+	x509Cmd.Flags().BoolVarP(&o.issuerCommonName, "issuer", "i", false, "Display issuer")
+	x509Cmd.Flags().BoolVarP(&o.subjectCommonName, "subject", "s", false, "Display subject")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/kanywst/s3heck
+
+go 1.20
+
+require github.com/spf13/cobra v1.7.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,0 +1,28 @@
+/*
+Copyright © 2023 kanywst ash00le1234@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package main
+
+import "github.com/kanywst/s3heck/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -5,9 +5,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"strings"
 )
 
-func GetX509Information(inputCertificate string, issuer bool, subject bool, validity bool) (d string) {
+func GetX509Information(inputCertificate string, issuer bool, subject bool, validity bool, dns bool) (d string) {
 	var (
 		chain     [][]byte
 		certBlock *pem.Block
@@ -24,7 +25,7 @@ func GetX509Information(inputCertificate string, issuer bool, subject bool, vali
 	}
 	for i, c := range chain {
 		cert, _ := x509.ParseCertificate(c)
-		d += fmt.Sprintf("Certificate [%d]\n", i)
+		d += fmt.Sprintf("Certificate [%d]\n", i+1)
 		if issuer {
 			d += fmt.Sprintf("%2sIssuer: %s\n", "", cert.Issuer.CommonName)
 		}
@@ -35,6 +36,10 @@ func GetX509Information(inputCertificate string, issuer bool, subject bool, vali
 			d += fmt.Sprintf("%2sValidity:\n", "")
 			d += fmt.Sprintf("%4sNotBefore: %s\n", "", cert.NotBefore)
 			d += fmt.Sprintf("%4sNotAfter: %s\n", "", cert.NotAfter)
+		}
+		if dns {
+			d += fmt.Sprintf("%2sX509v3 extensions\n", "")
+			d += fmt.Sprintf("%4sX509v3 Subject Alternative Name: %s\n", "", strings.Join(cert.DNSNames, ", "))
 		}
 	}
 	return

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -1,0 +1,36 @@
+package certificate
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+)
+
+func GetX509Information(inputCertificate string, issuer bool, subject bool) (d string) {
+	var (
+		chain     [][]byte
+		certBlock *pem.Block
+	)
+	certBytes, _ := ioutil.ReadFile(inputCertificate)
+	for {
+		certBlock, certBytes = pem.Decode(certBytes)
+		if certBlock == nil {
+			break
+		}
+		if certBlock.Type == "CERTIFICATE" {
+			chain = append(chain, certBlock.Bytes)
+		}
+	}
+	for _, c := range chain {
+		cert, _ := x509.ParseCertificate(c)
+		if issuer {
+			d += fmt.Sprintf("Issuer CN: %s\n", cert.Issuer.CommonName)
+		}
+		if subject {
+			d += fmt.Sprintf("Subject CN: %s\n", cert.Subject.CommonName)
+		}
+		d += "\n"
+	}
+	return
+}

--- a/pkg/certificate/certificate.go
+++ b/pkg/certificate/certificate.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 )
 
-func GetX509Information(inputCertificate string, issuer bool, subject bool) (d string) {
+func GetX509Information(inputCertificate string, issuer bool, subject bool, validity bool) (d string) {
 	var (
 		chain     [][]byte
 		certBlock *pem.Block
@@ -22,15 +22,20 @@ func GetX509Information(inputCertificate string, issuer bool, subject bool) (d s
 			chain = append(chain, certBlock.Bytes)
 		}
 	}
-	for _, c := range chain {
+	for i, c := range chain {
 		cert, _ := x509.ParseCertificate(c)
+		d += fmt.Sprintf("Certificate [%d]\n", i)
 		if issuer {
-			d += fmt.Sprintf("Issuer CN: %s\n", cert.Issuer.CommonName)
+			d += fmt.Sprintf("%2sIssuer: %s\n", "", cert.Issuer.CommonName)
 		}
 		if subject {
-			d += fmt.Sprintf("Subject CN: %s\n", cert.Subject.CommonName)
+			d += fmt.Sprintf("%2sSubject: %s\n", "", cert.Subject.CommonName)
 		}
-		d += "\n"
+		if validity {
+			d += fmt.Sprintf("%2sValidity:\n", "")
+			d += fmt.Sprintf("%4sNotBefore: %s\n", "", cert.NotBefore)
+			d += fmt.Sprintf("%4sNotAfter: %s\n", "", cert.NotAfter)
+		}
 	}
 	return
 }


### PR DESCRIPTION
# Description

Add option about display issuer,subject, validity, X509v3 Subject Alternative Name

# Usage

## Help

```bash
$ s3heck x509 -h
display necessary information about x509 certificates

Usage:
  s3heck x509 [flags]

Flags:
  -d, --dns          display subject alternative name
  -h, --help         help for x509
  -i, --issuer       display issuer
  -p, --pem string   specify certificate input pem
  -s, --subject      display subject
  -v, --validity     display validity
```

## Example

```bash
$ s3heck x509 -p ./data/cert.pem --issuer --subject --validity --dns
Certificate [1]
  Issuer: R3
  Subject: kanywst.top
  Validity:
    NotBefore: 2023-03-31 13:32:00 +0000 UTC
    NotAfter: 2023-06-29 13:31:59 +0000 UTC
  X509v3 extensions
    X509v3 Subject Alternative Name: kanywst.top, tbow.kanywst.top
Certificate [2]
  Issuer: ISRG Root X1
  Subject: R3
  Validity:
    NotBefore: 2020-09-04 00:00:00 +0000 UTC
    NotAfter: 2025-09-15 16:00:00 +0000 UTC
  X509v3 extensions
    X509v3 Subject Alternative Name: 
Certificate [3]
  Issuer: DST Root CA X3
  Subject: ISRG Root X1
  Validity:
    NotBefore: 2021-01-20 19:14:03 +0000 UTC
    NotAfter: 2024-09-30 18:14:03 +0000 UTC
  X509v3 extensions
    X509v3 Subject Alternative Name: 
```